### PR TITLE
fix: camera process fail to start

### DIFF
--- a/rear_rider_device/camera_child_proc.py
+++ b/rear_rider_device/camera_child_proc.py
@@ -56,6 +56,6 @@ class CameraChildProcess(ChildProcess):
         An empty function.
 
         An inheriting class can override this method to customize what happens when the
-        child process is done communicating with the parent process.
+        child process does not have a handler for a specified message (on_command) type.
         """
         pass

--- a/rear_rider_device/camera_child_proc.py
+++ b/rear_rider_device/camera_child_proc.py
@@ -1,48 +1,61 @@
+import os
 import asyncio
 from datetime import datetime
 from ipc.child_process import ChildProcess
-from typing import Deque
 
-from bluetooth_server_child_proc import BluetoothServerChildProcess
-
-import os 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 class CameraChildProcess(ChildProcess):
-    def __init__(self, bt_server_proc: BluetoothServerChildProcess):
+    def __init__(self):
+        super().__init__(f'python {dir_path}/camera_proc.py')
         self.ready = asyncio.Future()
-        #self.bt_server_proc = bt_server_proc
+        self.start_time = datetime.now()
+
+
+    def _get_name(self) -> str:
+        return 'CameraChildProcess'
 
     async def on_ready(self):
         """
         An empty function.
 
-        An inheriting class can override this method to customize what happens when the child process is ready for communication
+        An inheriting class can override this method to customize what happens when the
+        child process is ready for communication
         """
         self.start_time = datetime.now()
         self._print('CameraChildProcess is ready.')
-        # try:
-            # await self.writeline('ready_ack')
+
         try:
             await self.writeline('get_stream')
-        except:
-            pass
+        except Exception as ex:
+            print(ex)
         self.ready.set_result(None)
         self._print('after_on_ready')
-    
+
 
     async def on_wait_ready(self):
         """
         An empty function.
 
-        An inheriting class can override this method to customize what happens before the parent process receives a ready signal from the child process.
+        An inheriting class can override this method to customize what happens before the
+        parent process receives a ready signal from the child process.
         """
         pass
-    
+
     def on_done(self):
         """
         An empty function.
 
-        An inheriting class can override this method to customize what happens when the child process is done communicating with the parent process. 
+        An inheriting class can override this method to customize what happens when the
+        child process is done communicating with the parent process.
+        """
+        pass
+
+    def no_on_handler(self, on_command, err):
+        """
+        An empty function.
+
+        An inheriting class can override this method to customize what happens when the
+        child process is done communicating with the parent process.
         """
         pass


### PR DESCRIPTION
- Fixes the init of the camera child process so it calls super and initializes without crashing
- Adds a print statement to the exception instead of just passing
- Formatting cleanup, such as removing unused code and shortening lines that are over the pylint recommended length