### PR TITLE
Bug fix and lidar child process now works with input from lidar sensor 

### DIFF
--- a/rear_rider_device/lidar_child_proc.py
+++ b/rear_rider_device/lidar_child_proc.py
@@ -11,8 +11,8 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 class LidarChildProcess(ChildProcess):
 
-    lidar_distance = 0
-    lidar_strength = 0
+    lidar_distance = 0 # default unit is cm
+    signal_strength = 0 # signal unreliable under 100 
 
     def __init__(self, led_child_proc: LedsChildProcess):
         """
@@ -38,12 +38,11 @@ class LidarChildProcess(ChildProcess):
     async def on_data(self):
         lidar_data = (await self.readline()).split(' ')
         lidar_distance = lidar_data[0]
-        strength = lidar_data[1]
-        self._print('lidar_distance:{}\n\tSignalStrength:{}\n'.format(lidar_distance, strength))
+        signal_strength = lidar_data[1]
+        self._print('Lidar_distance:{}\n\tSignal_strength:{}\n'.format(lidar_distance, signal_strength))
         
-        # send led notification
-        unsafe_lidar_ = 300 # default unit is cm
-        if lidar_distance < unsafe_lidar_:
+        unsafe_distance = 300 
+        if lidar_distance < unsafe_distance:
             await self.led_child_proc.led_strobe_on()
         
         await asyncio.sleep(1.0/100)

--- a/rear_rider_device/lidar_child_proc.py
+++ b/rear_rider_device/lidar_child_proc.py
@@ -55,5 +55,5 @@ class test_lidar_proc(LidarChildProcess):
         self._program = 'python {}/test_lidar_proc.py'.format(dir_path)
 
 if(__name__ == "__main__"):
-    myTest=test_lidar_proc()
-    asyncio.run(myTest.begin())
+    LidarChildProcess = LidarChildProcess()
+    asyncio.run(LidarChildProcess.begin())

--- a/rear_rider_device/rear_rider_sensors/lidar.py
+++ b/rear_rider_device/rear_rider_sensors/lidar.py
@@ -16,31 +16,14 @@ class Lidar():
             if count > 8:
                 recv = ser.read(9)   # Read up to 9 bytes
                 ser.reset_input_buffer() # Clear the buffer
-                # type(recv), 'str' in python2(recv[0] = 'Y'), 'bytes' in python3(recv[0] = 89)
-                # type(recv[0]), 'str' in python2, 'int' in python3 
+                # type(recv[0]),  'int' in python3 
                 
                 if recv[0] == 0x59 and recv[1] == 0x59:     #python3
                     distance = recv[2] + recv[3] * 256
                     strength = recv[4] + recv[5] * 256
-                    # print('(', distance, ',', strength, ')')
                     # print("Distatnce: %3.2fm Signal Strength: %d"%((distance * 0.01), strength))
                     ser.reset_input_buffer()
                     return distance, strength
-                    
-                # if recv[0] == 'Y' and recv[1] == 'Y':     #python2
-                #     lowD = int(recv[2].encode('hex'), 16)      
-                #     highD = int(recv[3].encode('hex'), 16)
-                #     lowS = int(recv[4].encode('hex'), 16)      
-                #     highS = int(recv[5].encode('hex'), 16)
-                #     distance = lowD + highD * 256
-                #     strength = lowS + highS * 256
-                #     print(distance, strength)
-                
-                # you can also distinguish python2 and python3: 
-                #import sys
-                #sys.version[0] == '2'    #True, python2
-                #sys.version[0] == '3'    #True, python3
-
 
 if __name__ == '__main__':
     lidar = Lidar()

--- a/rear_rider_device/rear_rider_sensors/lidar.py
+++ b/rear_rider_device/rear_rider_sensors/lidar.py
@@ -8,6 +8,7 @@ class Lidar():
     def __init__(self) -> None:
         pass
 
+    @staticmethod
     def getTFminiData():
         while True:
             #time.sleep(0.1)


### PR DESCRIPTION
bug in lidar.py line 11, getTFminiData() should be a static method

Updated lidar_child_proc.py now works with the lidar sensor input