### PR TITLE
De33 turning off strobe light

### DIFF
--- a/rear_rider_device/actuators/led_strip.py
+++ b/rear_rider_device/actuators/led_strip.py
@@ -3,7 +3,7 @@ from threading import Condition
 import time
 import board
 import neopixel
-GPIO_PIN = board.D18
+GPIO_PIN = board.D21
 NUM_PIXELS = 16
 INIT_BRIGHTNESS = 0.1
 

--- a/rear_rider_device/leds_proc.py
+++ b/rear_rider_device/leds_proc.py
@@ -3,7 +3,7 @@ from sys import path
 from threading import Thread
 from typing import Union
 from ipc.parent_process import ParentProcess
-from actuators.led_strip import LedStripController, LedStripFrame, LedsEffectsLoopContext, StrobeEffect, create_neopixel, enter_leds_effects_loop
+from actuators.led_strip import BlankEffect, LedStripController, LedStripFrame, LedsEffectsLoopContext, StrobeEffect, create_neopixel, enter_leds_effects_loop
 
 path.append("rear_rider_bluetooth_server/src/")
 
@@ -62,7 +62,7 @@ class LedsParentProcess(ParentProcess):
         params_line = await self.readline()
         params = params_line.split(' ')
         frequency = int(params[0])
-        duration = float(params[1])
+        # duration = float(params[1])
         self._set_strobe_effect(frequency, WHITE)
 
     async def pre_ready(self):
@@ -110,7 +110,8 @@ class LedsParentProcess(ParentProcess):
         )
     
     async def on_strobe_off(self):
-        self._leds_effects_loop_ctx.set_effects([])
+        self._leds_effects_loop_ctx.set_effects([BlankEffect()])
+        self._leds_effects_loop_ctx.play()
     
     def _join_leds_thread(self):
         if self._leds_effects_loop_thread is not None:


### PR DESCRIPTION
[DE33](https://rally1.rallydev.com/#/?detail=/defect/668475576907&fdp=true): Turning off Strobe light

This fixes that weird bug where when the strobe light is turned on while the light is in an illuminating state, then the strobe light would stay illuminated until it is triggered to turn back on.
