### PR TITLE
Changes to the way imports are handled in the python code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+*__pycache__

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ include-system-site-packages = true
 source .venv/bin/activate
 # Install the required python packages from pip.
 pip install -r ./requirements.txt
-# Change the working directory to the rear rider device directory.
-cd ./rear_rider_device
-python ./main.py
+python ./rear_rider_device/main.py
 ```
 
 ## Creating a systemd service

--- a/rear_rider_device/accel_proc.py
+++ b/rear_rider_device/accel_proc.py
@@ -1,9 +1,18 @@
+import sys
+import os
+PROJECT_ROOT = os.path.abspath(os.path.join(
+                os.path.dirname(__file__),
+                # This file should be in `rear_rider_device/` so we need to travel up one directory.
+                f'{os.pardir}')
+)
+sys.path.append(PROJECT_ROOT)
+
 import asyncio
-from ipc.parent_process import ParentProcess
-import rear_rider_sensors.accelerometer as accelerometer
+from rear_rider_device.ipc.parent_process import ParentProcess
+from rear_rider_device.rear_rider_sensors.accelerometer import Accelerometer
 
 class AccelerometerParentProcess(ParentProcess):
-    def __init__(self, accelerometer: accelerometer.Accelerometer):
+    def __init__(self, accelerometer: Accelerometer):
         self.accelerometer = accelerometer
 
     async def pre_ready(self):
@@ -29,7 +38,7 @@ class AccelerometerParentProcess(ParentProcess):
 
 if __name__ == '__main__':
     try:
-        accelerometer = accelerometer.Accelerometer()
+        accelerometer = Accelerometer()
     except ValueError as e:
         print(f'exception\n{e}')
         exit()

--- a/rear_rider_device/accelerometer_child_proc.py
+++ b/rear_rider_device/accelerometer_child_proc.py
@@ -1,9 +1,9 @@
 import asyncio
 from datetime import datetime
-from ipc.child_process import ChildProcess
+from rear_rider_device.ipc.child_process import ChildProcess
 from typing import Deque
 
-from bluetooth_server_child_proc import BluetoothServerChildProcess
+from rear_rider_device.bluetooth_server_child_proc import BluetoothServerChildProcess
 
 import os 
 dir_path = os.path.dirname(os.path.realpath(__file__))

--- a/rear_rider_device/bluetooth.py
+++ b/rear_rider_device/bluetooth.py
@@ -1,21 +1,21 @@
+import sys
+import os
+PROJECT_ROOT = os.path.abspath(os.path.join(
+                os.path.dirname(__file__),
+                # This file should be in `rear_rider_device/` so we need to travel up one directory.
+                f'{os.pardir}')
+)
+sys.path.append(PROJECT_ROOT)
+
 import asyncio
 import concurrent.futures
 from concurrent.futures import Future, ThreadPoolExecutor
-from pkgutil import get_data
-import readline
-from sys import stdout, path
-from typing import Any, Callable, Union
+from typing import Any, Callable
 
-
-path.append("rear_rider_bluetooth_server/src/")
-path.append("rear_rider_bluetooth_server/src/services")
-path.append("rear_rider_bluetooth_server/src/services/characteristics")
-
-from rear_rider_bluetooth_server.src.services.characteristics.strobe_light import StrobeLight
-from rear_rider_bluetooth_server.src.services.sensors import SensorsService
-from ipc.parent_process import ParentProcess
-import rear_rider_bluetooth_server.src.main as bt_server_main
-from rear_rider_bluetooth_server.src.services.hello_world import HelloWorldService, LedConfig
+from rear_rider_device.ipc.parent_process import ParentProcess
+from rear_rider_device.rear_rider_bluetooth_server.src.services.characteristics.strobe_light import StrobeLight
+import rear_rider_device.rear_rider_bluetooth_server.src.main as bt_server_main
+from rear_rider_device.rear_rider_bluetooth_server.src.services.hello_world import LedConfig
 
 class BluetoothParentProcess(ParentProcess):
     rear_rider_bt: bt_server_main.RearRiderBluetooth

--- a/rear_rider_device/bluetooth_server_child_proc.py
+++ b/rear_rider_device/bluetooth_server_child_proc.py
@@ -1,11 +1,11 @@
 import asyncio
 import concurrent.futures
-from ipc.child_process import ChildProcess
-from ipc.parent_process import ParentProcess
+from rear_rider_device.ipc.child_process import ChildProcess
+from rear_rider_device.ipc.parent_process import ParentProcess
 
 import os
 
-from leds_child_proc import LedsChildProcess
+from rear_rider_device.leds_child_proc import LedsChildProcess
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 

--- a/rear_rider_device/ipc/child_process.py
+++ b/rear_rider_device/ipc/child_process.py
@@ -1,7 +1,7 @@
 import asyncio
 import threading
 from typing import Union
-from ipc.i_process import Process
+from rear_rider_device.ipc.i_process import Process
 
 class ChildProcess(Process):
     """

--- a/rear_rider_device/ipc/parent_process.py
+++ b/rear_rider_device/ipc/parent_process.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from sys import stdin, stdout
-from ipc.i_process import Process
+from rear_rider_device.ipc.i_process import Process
 
 class ParentProcess(Process):
     """

--- a/rear_rider_device/leds_child_proc.py
+++ b/rear_rider_device/leds_child_proc.py
@@ -1,10 +1,10 @@
 import asyncio
 import concurrent.futures
-from ipc.child_process import ChildProcess
+from rear_rider_device.ipc.child_process import ChildProcess
 
 import os
 
-from ipc.parent_process import ParentProcess 
+from rear_rider_device.ipc.parent_process import ParentProcess 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 DEFAULT_STROBE_VALUE = '5 0'

--- a/rear_rider_device/leds_proc.py
+++ b/rear_rider_device/leds_proc.py
@@ -1,11 +1,17 @@
+import sys
+import os
+PROJECT_ROOT = os.path.abspath(os.path.join(
+                os.path.dirname(__file__),
+                # This file should be in `rear_rider_device/` so we need to travel up one directory.
+                f'{os.pardir}')
+)
+sys.path.append(PROJECT_ROOT)
+
 import asyncio
-from sys import path
 from threading import Thread
 from typing import Union
-from ipc.parent_process import ParentProcess
-from actuators.led_strip import BlankEffect, LedStripController, LedStripFrame, LedsEffectsLoopContext, StrobeEffect, create_neopixel, enter_leds_effects_loop
-
-path.append("rear_rider_bluetooth_server/src/")
+from rear_rider_device.ipc.parent_process import ParentProcess
+from rear_rider_device.actuators.led_strip import BlankEffect, LedStripController, LedStripFrame, LedsEffectsLoopContext, StrobeEffect, create_neopixel, enter_leds_effects_loop
 
 WHITE = (255, 255, 255)
 OFF_COLOR = (0,0,0)

--- a/rear_rider_device/lidar_child_proc.py
+++ b/rear_rider_device/lidar_child_proc.py
@@ -2,9 +2,8 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 import concurrent.futures
 from datetime import datetime
-from ipc.child_process import ChildProcess
-# from typing import Deque
-from leds_child_proc import LedsChildProcess
+from rear_rider_device.ipc.child_process import ChildProcess
+from rear_rider_device.leds_child_proc import LedsChildProcess
 import os 
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -18,7 +17,7 @@ class LidarChildProcess(ChildProcess):
         """
         Default `buf_size` of 64 frame datapoints at 60 `fps`.
         """
-        super().__init__('python {}/lidar_proc.py'.format(dir_path))
+        super().__init__('sudo python {}/lidar_proc.py'.format(dir_path))
         self.ready = asyncio.Future()
         self.led_child_proc = led_child_proc
         

--- a/rear_rider_device/lidar_child_proc.py
+++ b/rear_rider_device/lidar_child_proc.py
@@ -17,7 +17,7 @@ class LidarChildProcess(ChildProcess):
         """
         Default `buf_size` of 64 frame datapoints at 60 `fps`.
         """
-        super().__init__('sudo python {}/lidar_proc.py'.format(dir_path))
+        super().__init__('python {}/lidar_proc.py'.format(dir_path))
         self.ready = asyncio.Future()
         self.led_child_proc = led_child_proc
         

--- a/rear_rider_device/lidar_proc.py
+++ b/rear_rider_device/lidar_proc.py
@@ -1,9 +1,15 @@
 import asyncio
-from pkgutil import get_data
-import readline
-from sys import stdout
-from ipc.parent_process import ParentProcess
-import rear_rider_sensors.lidar as lidar
+import sys
+import os
+PROJECT_ROOT = os.path.abspath(os.path.join(
+                os.path.dirname(__file__),
+                # This file should be in `rear_rider_device/` so we need to travel up one directory.
+                f'{os.pardir}')
+)
+sys.path.append(PROJECT_ROOT)
+
+from rear_rider_device.ipc.parent_process import ParentProcess
+import rear_rider_device.rear_rider_sensors.lidar as lidar
 
 class LidarParentProcess(ParentProcess):
     def __init__(self, lidar: lidar.Lidar):

--- a/rear_rider_device/main.py
+++ b/rear_rider_device/main.py
@@ -1,13 +1,20 @@
+import os
+import sys
+PROJECT_ROOT = os.path.abspath(os.path.join(
+                  os.path.dirname(__file__),
+                  f'{os.pardir}')
+)
+sys.path.append(PROJECT_ROOT)
+
 import asyncio
 import concurrent.futures
-from ipc.i_process import Process
-from accelerometer_child_proc import AccelerometerChildProcess
-from bluetooth_server_child_proc import BluetoothServerChildProcess
-from camera_child_proc import CameraChildProcess
+from rear_rider_device.ipc.i_process import Process
+from rear_rider_device.accelerometer_child_proc import AccelerometerChildProcess
+from rear_rider_device.bluetooth_server_child_proc import BluetoothServerChildProcess
+from rear_rider_device.camera_child_proc import CameraChildProcess
+from rear_rider_device.lidar_child_proc import LidarChildProcess
 
-import os
-
-from leds_child_proc import LedsChildProcess 
+from rear_rider_device.leds_child_proc import LedsChildProcess 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 def main():
@@ -16,11 +23,13 @@ def main():
             leds_child_process=leds_child_proc)
     accelerometer_proc = AccelerometerChildProcess(buf_size=32, fps=1,
         bt_server_proc=bt_server_process)
+    lidar_child_proc = LidarChildProcess(led_child_proc=leds_child_proc)
     # camera_proc = CameraChildProcess(bt_server_proc=bt_server_process)
     child_processes: list[Process] = [
         leds_child_proc,
         accelerometer_proc,
         bt_server_process,
+        lidar_child_proc
         # camera_proc
     ]
     futures = []

--- a/rear_rider_device/rear_rider_bluetooth_server/src/advertisement/rear_rider_adv.py
+++ b/rear_rider_device/rear_rider_bluetooth_server/src/advertisement/rear_rider_adv.py
@@ -1,5 +1,4 @@
-from bluez.example_advertisement import Advertisement
-
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_advertisement import Advertisement
 
 class RearRiderAdvertisement(Advertisement):
     

--- a/rear_rider_device/rear_rider_bluetooth_server/src/main.py
+++ b/rear_rider_device/rear_rider_bluetooth_server/src/main.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
-import signal
 from sys import stdout
 from typing import Callable, Literal, Union
 
-from advertisement.rear_rider_adv import RearRiderAdvertisement
+from rear_rider_device.rear_rider_bluetooth_server.src.advertisement.rear_rider_adv import RearRiderAdvertisement
 
-from bluez.example_advertisement import LE_ADVERTISING_MANAGER_IFACE
-from bluez.example_gatt_server import find_adapter, dbus, BLUEZ_SERVICE_NAME, GATT_MANAGER_IFACE
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_advertisement import LE_ADVERTISING_MANAGER_IFACE
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_gatt_server import find_adapter, dbus, BLUEZ_SERVICE_NAME, GATT_MANAGER_IFACE
 from gi.repository import GLib
-from agent.simple import Agent
-from bluetooth_device import BluetoothDevice
+from rear_rider_device.rear_rider_bluetooth_server.src.agent.simple import Agent
+from rear_rider_device.rear_rider_bluetooth_server.src.bluetooth_device import BluetoothDevice
 
-from services.hello_world import HelloWorldService
-from services.characteristics.strobe_light import StrobeLight
-from services.sensors import SensorsService
+from rear_rider_device.rear_rider_bluetooth_server.src.services.hello_world import HelloWorldService
+from rear_rider_device.rear_rider_bluetooth_server.src.services.characteristics.strobe_light import StrobeLight
+from rear_rider_device.rear_rider_bluetooth_server.src.services.sensors import SensorsService
 
-from rearrider_app import RearRiderApplication
+from rear_rider_device.rear_rider_bluetooth_server.src.rearrider_app import RearRiderApplication
 
 AGENT_MANAGER_IFACE = 'org.bluez.AgentManager1'
 AGENT_PATH = '/bluez/simpleagent'

--- a/rear_rider_device/rear_rider_bluetooth_server/src/rearrider_app.py
+++ b/rear_rider_device/rear_rider_bluetooth_server/src/rearrider_app.py
@@ -1,8 +1,8 @@
-from bluez.example_gatt_server import Service, dbus, DBUS_OM_IFACE
-from services.sensors import SensorsService
-from services.hello_world import HelloWorldService
-from services.actuators import ActuatorsService
-from services.characteristics.strobe_light import StrobeLight
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_gatt_server import Service, dbus, DBUS_OM_IFACE
+from rear_rider_device.rear_rider_bluetooth_server.src.services.sensors import SensorsService
+from rear_rider_device.rear_rider_bluetooth_server.src.services.hello_world import HelloWorldService
+from rear_rider_device.rear_rider_bluetooth_server.src.services.actuators import ActuatorsService
+from rear_rider_device.rear_rider_bluetooth_server.src.services.characteristics.strobe_light import StrobeLight
 
 class RearRiderApplication(dbus.service.Object):
     """

--- a/rear_rider_device/rear_rider_bluetooth_server/src/services/actuators.py
+++ b/rear_rider_device/rear_rider_bluetooth_server/src/services/actuators.py
@@ -1,5 +1,5 @@
-from bluez.example_gatt_server import Service
-from services.characteristics.strobe_light import StrobeLightCharacteristic, StrobeLight
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_gatt_server import Service
+from rear_rider_device.rear_rider_bluetooth_server.src.services.characteristics.strobe_light import StrobeLightCharacteristic, StrobeLight
 
 
 class ActuatorsService(Service):

--- a/rear_rider_device/rear_rider_bluetooth_server/src/services/characteristics/strobe_light.py
+++ b/rear_rider_device/rear_rider_bluetooth_server/src/services/characteristics/strobe_light.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Callable
-from bluez.example_gatt_server import Characteristic, Descriptor, dbus
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_gatt_server import Characteristic, Descriptor, dbus
 
 @dataclass
 class StrobeLight:

--- a/rear_rider_device/rear_rider_bluetooth_server/src/services/hello_world.py
+++ b/rear_rider_device/rear_rider_bluetooth_server/src/services/hello_world.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Callable, Union
-from bluez.example_gatt_server import GATT_CHRC_IFACE, Characteristic, Service, GObject, dbus
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_gatt_server import GATT_CHRC_IFACE, Characteristic, Service, GObject, dbus
 import subprocess
 
 WLAN_INTERFACE = 'wlan'

--- a/rear_rider_device/rear_rider_bluetooth_server/src/services/sensors.py
+++ b/rear_rider_device/rear_rider_bluetooth_server/src/services/sensors.py
@@ -1,6 +1,6 @@
 from sys import stdin, stdout
 from typing import Callable
-from bluez.example_gatt_server import dbus, GATT_CHRC_IFACE, Characteristic, Service, GObject
+from rear_rider_device.rear_rider_bluetooth_server.src.bluez.example_gatt_server import dbus, GATT_CHRC_IFACE, Characteristic, Service, GObject
 
 class SensorsService(Service):
     """
@@ -47,6 +47,7 @@ class AccelerometerCharacteristic(Characteristic):
         self.notifying = False
 
     def ReadValue(self, options):
+        # TODO: Move this into a callback function.
         line = 'accelerometer'
         if line != 'accelerometer':
             return

--- a/test/test_rear_rider_device/test_child.py
+++ b/test/test_rear_rider_device/test_child.py
@@ -1,5 +1,5 @@
 import asyncio
-from parent_process import ParentProcess
+from rear_rider_device.ipc.parent_process import ParentProcess
 
 
 class TestParentProcess(ParentProcess):


### PR DESCRIPTION
- Vscode python linter does not show red error squiggles for imports.
  - Import paths were updated during runtime, so the python linter did not detect it during static analysis and thus the error squiggles were born.
- Allows for running `main.py` in the project root directory.
  - Removes the need for cd'ing into the `rear_rider_device` directory.
  - `README.md` is updated to reflect this.