### PR TITLE
this is just a change to the ipc tests because they used user input t…

### DIFF
--- a/test/test_rear_rider_device/test_ipc/test_leds_child_proc.py
+++ b/test/test_rear_rider_device/test_ipc/test_leds_child_proc.py
@@ -1,3 +1,11 @@
+import os
+import sys
+PROJECT_ROOT = os.path.abspath(os.path.join(
+                  os.path.dirname(__file__),
+                  f'{os.pardir}/..')
+)
+sys.path.append(PROJECT_ROOT + "/..") #"../rear_rider_device"
+#print("************",sys.path, "************")
 from rear_rider_device.leds_child_proc import LedsChildProcess
 import unittest
 import threading
@@ -37,24 +45,37 @@ class ManualTestLedsChildProcess(unittest.IsolatedAsyncioTestCase):
         '''
         Set the discoverable effect on, then turn it off.
         '''
+        t_f_dict = dict()
+        
         await self._leds_child_process.set_discoverable_effect(True)
-        self.assertTypeYToPass('Is the discoverable effect on?')
+        t_f_dict["on"] = await self._leds_child_process.is_strobe_on()
 
         await self._leds_child_process.set_discoverable_effect(False)
-        self.assertTypeYToPass('Is the discoverable effect off?')
+        t_f_dict["off"] = await self._leds_child_process.is_strobe_on()
+        check_dict = {"on" :True, 
+                      "off":False}
+        self.assertDictEqual(t_f_dict, check_dict)
     
     async def test_is_strobe_on(self):
         '''
         Return true if the strobe light is on.
         '''
         await self._leds_child_process.led_strobe_on()
-        await self._leds_child_process.is_strobe_on()
-        self.assertTypeYToPass('Is the strobe light on and does the line above read "True"?')
-
+        val = await self._leds_child_process.is_strobe_on()
         await self._leds_child_process.led_strobe_off()
-        await self._leds_child_process.is_strobe_on()
-        self.assertTypeYToPass('Is the strobe light off and does the line above read "False"?')
 
+        self.assertTrue(val)
+        
+    async def test_is_strobe_off(self):
+        '''
+        Return false if the strobe light is off.
+        '''
+        await self._leds_child_process.led_strobe_on()
+        await self._leds_child_process.led_strobe_off()
+        val = await self._leds_child_process.is_strobe_on()
+
+        self.assertFalse(val)
+        
     def test_add_led_effect(self):
         '''
         Adding a strobe effect.
@@ -65,5 +86,6 @@ def test_cases():
     return [
         ManualTestLedsChildProcess('test_set_discoverable_effect'),
         ManualTestLedsChildProcess('test_is_strobe_on'),
-        # ManualTestLedsChildProcess('test_add_led_effect')
+        ManualTestLedsChildProcess('test_is_strobe_off')
+        #ManualTestLedsChildProcess('test_add_led_effect')
     ]


### PR DESCRIPTION
…o verify that they were working. This gets rid of the user input portion by testing what the functions actually do in them instead of whether or not the hardware is working. - Brock Morris